### PR TITLE
Feature/improve aws services

### DIFF
--- a/src/Matiux/DDDStarterPack/Message/Infrastructure/Driver/AWS/SQS/SQSMessageConsumer.php
+++ b/src/Matiux/DDDStarterPack/Message/Infrastructure/Driver/AWS/SQS/SQSMessageConsumer.php
@@ -87,7 +87,6 @@ class SQSMessageConsumer extends BasicMessageService implements MessageConsumerC
             $messageAttributes = (array) $body['MessageAttributes'];
             $body = (string) $body['Message'];
         } else {
-            // Invio diretto di un messaggio su cosa SQS
             // Opzione della sottoscrizione "Enable raw message delivery" attivata
             $messageAttributes = (array) $message['MessageAttributes'];
             $body = (string) json_encode($body);

--- a/src/Matiux/DDDStarterPack/Message/Infrastructure/Driver/AWS/SQS/SQSMessageConsumer.php
+++ b/src/Matiux/DDDStarterPack/Message/Infrastructure/Driver/AWS/SQS/SQSMessageConsumer.php
@@ -80,21 +80,24 @@ class SQSMessageConsumer extends BasicMessageService implements MessageConsumerC
      */
     private function parseMessage(array $message): array
     {
-        $body = (array) json_decode((string) $message['Body'], true);
+        $originalBody = (array) json_decode((string) $message['Body'], true);
 
-        if (array_key_exists('MessageAttributes', $body)) {
-            // Opzione della sottoscrizione "Enable raw message delivery" disabilitata
-            $messageAttributes = (array) $body['MessageAttributes'];
-            $body = (string) $body['Message'];
+        if ($this->isSnsRawMessageDeliveryEnabled($originalBody)) {
+            $body = (string) $originalBody['Message'];
+            $messageAttributes = (array) ($originalBody['MessageAttributes'] ?? []);
         } else {
-            // Opzione della sottoscrizione "Enable raw message delivery" attivata
-            $messageAttributes = (array) $message['MessageAttributes'];
-            $body = (string) json_encode($body);
+            $body = (string) json_encode($originalBody);
+            $messageAttributes = (array) ($message['MessageAttributes'] ?? []);
         }
 
         $messageAttributes = $this->prepareMessageAttributes($messageAttributes);
 
         return [$body, $messageAttributes];
+    }
+
+    private function isSnsRawMessageDeliveryEnabled(array $originalBody): bool
+    {
+        return array_key_exists('MessageId', $originalBody) && array_key_exists('Message', $originalBody);
     }
 
     /**


### PR DESCRIPTION
We have fixed the following:
1)`SQSMessageConsumer` now supports all different type of message formats:
- SNS raw message delivery disabled with MessageAttributes
- SNS raw message delivery disabled without MessageAttributes
- SNS raw message delivery enabled with MessageAttributes
- SNS raw message delivery enabled without MessageAttributes

2)`SNSMessagePublisher` now throws an `MessageInvalidException` if the SNSClient's publish method fails