### PR TITLE
Feature/fix filters

### DIFF
--- a/makefile
+++ b/makefile
@@ -109,6 +109,10 @@ phpunit: ## Esegue tutta la suite di test generando anche il badge. Oppure uno s
 coverage: ## Esegue tutta la suite di test e verifica la coverage generando anche il badge
 	$(COMPOSE_EXEC_PHP) $(PROJECT_TOOL) coverage
 
+.PHONY: create-schema
+create-schema: ## Create database schema for test execution
+	$(COMPOSE_EXEC_PHP) $(PROJECT_TOOL) doctrine-schema-create
+
 # Static analysis ——————————————————————————————————————————————————————————————————————————————————————————————————————
 
 .PHONY: psalm
@@ -131,7 +135,7 @@ check-deps-vulnerabilities: ## Check per le vulnerabilità sulle dipendenze
 deptrac-table-all: ## Esegue deptrac per la verifica dei vincoli architetturali
 	$(COMPOSE_EXEC_PHP_NO_PSEUSO_TTY) $(PROJECT_TOOL) deptrac-table-all $$ARG
 
-# Deptrac ——————————————————————————————————————————————————————————————————————————————————————————————————————————————
+# Infection ————————————————————————————————————————————————————————————————————————————————————————————————————————————
 
 .PHONY: infection
 infection: ## Esegue infection per test di mutazione

--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,7 @@ make composer ARG=install
 ```bash
 make build-php ARG=--no-cache
 make upd
+make create-schema
 make test
 ```
 

--- a/src/Matiux/DDDStarterPack/Aggregate/Domain/Repository/Filter/FilterAppliersRegistry.php
+++ b/src/Matiux/DDDStarterPack/Aggregate/Domain/Repository/Filter/FilterAppliersRegistry.php
@@ -21,23 +21,17 @@ class FilterAppliersRegistry
      */
 
     /**
-     * @param string $key
-     * @param string $default
-     *
      * @throws \InvalidArgumentException
      *
      * @return mixed
      */
-    public function getFilterValueForKey(string $key, string $default = ''): mixed
+    public function getFilterValueForKey(string $key, string $default = null): mixed
     {
-        if (
-            isset($this->requestedFilters[$key])
-            && !empty($this->requestedFilters[$key])
-        ) {
+        if (array_key_exists($key, $this->requestedFilters)) {
             return $this->requestedFilters[$key];
         }
 
-        return !empty($default) ? $default : throw new \InvalidArgumentException("Filter with key '{$key}' does not exist");
+        return $default ?? throw new \InvalidArgumentException("Filter with key '{$key}' does not exist");
     }
 
     public function applyToTarget(mixed $target): void

--- a/tests/Unit/DDDStarterPack/Aggregate/Domain/Repository/Filter/FilterAppliersRegistryTest.php
+++ b/tests/Unit/DDDStarterPack/Aggregate/Domain/Repository/Filter/FilterAppliersRegistryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\DDDStarterPack\Aggregate\Domain\Repository\Filter;
 
 use DDDStarterPack\Aggregate\Domain\Repository\Filter\FilterAppliersRegistry;
+use DDDStarterPack\Aggregate\Domain\Repository\Filter\FilterAppliersRegistryBuilder;
 use PHPUnit\Framework\TestCase;
 
 class FilterAppliersRegistryTest extends TestCase
@@ -38,5 +39,39 @@ class FilterAppliersRegistryTest extends TestCase
         $appliersRegistry = new FilterAppliersRegistry([], $requestedFilters);
 
         self::assertFalse($appliersRegistry->hasFilterWithKey('surname'));
+    }
+
+    /**
+     * @return array<array-key, array<array-key, mixed>>
+     */
+    public function provideValidEmptyValues(): array
+    {
+        return [
+            'int(0)' => [0],
+            'string("0")' => ['0'],
+            'string("")' => [''],
+            'bool(false)' => [false],
+            'null' => [null],
+            'empty array' => [[]],
+        ];
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider provideValidEmptyValues
+     */
+    public function it_should_not_fail_when_filter_applies_an_empty_value(mixed $value): void
+    {
+        $requestedFilters = ['some-value' => $value];
+        $appliersRegistry = (new FilterAppliersRegistryBuilder())->build($requestedFilters);
+        $target = new DummyArrayTarget();
+
+        (new DummyFilterApplier('some-value'))
+            ->applyTo($target, $appliersRegistry);
+
+        self::assertSame([
+            ['some-value' => $value],
+        ], $target->get());
     }
 }

--- a/tests/Unit/DDDStarterPack/Type/CollectionTest.php
+++ b/tests/Unit/DDDStarterPack/Type/CollectionTest.php
@@ -22,7 +22,38 @@ class CollectionTest extends TestCase
 
         $items = [$a, $b];
 
-        $this->collection = new Collection($items);
+        $this->collection = Collection::create($items);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_create_an_empty_collection(): void
+    {
+        $collection = Collection::create();
+
+        self::assertCount(0, $collection);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_create_a_collection_with_a_given_list_of_items(): void
+    {
+        $collection = Collection::create([1, 2, 3]);
+
+        self::assertCount(3, $collection);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_add_an_item_into_the_collection(): void
+    {
+        /** @var Collection<string> $collection */
+        $collection = Collection::create();
+
+        self::assertCount(1, $collection->add('some-item'));
     }
 
     /**
@@ -62,7 +93,7 @@ class CollectionTest extends TestCase
         $c = new MyData();
         $c->data = true;
 
-        $collection2 = new Collection([$c]);
+        $collection2 = Collection::create([$c]);
         $mergedCollection = $this->collection->merge($collection2);
 
         self::assertCount(3, $mergedCollection);


### PR DESCRIPTION
this PR includes the following additions:

- adds a new `create-schema` task in the makefile in order to initialize the database schema for testing (and updates the project docs)
- fixes a bug that causes a filter to crash when an empty value is applied (e.g. 0)
- makes the base `Collection` class immutable