### PR TITLE
fix: replaces self with static

### DIFF
--- a/src/Matiux/DDDStarterPack/Type/Collection.php
+++ b/src/Matiux/DDDStarterPack/Type/Collection.php
@@ -37,7 +37,7 @@ class Collection implements \Iterator, \Countable
      */
     final public static function create(array $items = []): static
     {
-        $instance = new self();
+        $instance = new static();
 
         foreach ($items as $item) {
             $instance = $instance->add($item);


### PR DESCRIPTION
replaces `new self` with `new static` in `Collection::create()`