### PR TITLE
fix: corrects timezone setting in DateTimeRFC::UTCfrom

### DIFF
--- a/src/Matiux/DDDStarterPack/Type/DateTimeRFC.php
+++ b/src/Matiux/DDDStarterPack/Type/DateTimeRFC.php
@@ -19,9 +19,9 @@ class DateTimeRFC extends \DateTimeImmutable
         parent::__construct($datetime, $timezone);
     }
 
-    public static function UTC(string $datetime = 'now'): static
+    public static function UTC(): static
     {
-        return new static($datetime,new \DateTimeZone('UTC'));
+        return new static(timezone: new \DateTimeZone('UTC'));
     }
 
     /**
@@ -43,11 +43,13 @@ class DateTimeRFC extends \DateTimeImmutable
 
     public static function UTCfrom(string $dateTime): static
     {
-        $tz = new \DateTimeZone('UTC');
-
-        if (!$date = static::createFromFormat(self::FORMAT, $dateTime, $tz)) {
+        if (!$date = static::createFromFormat(self::FORMAT, $dateTime)) {
             throw new \InvalidArgumentException(sprintf('Data non valida: %s', $dateTime));
         }
+
+        $tz = new \DateTimeZone('UTC');
+
+        $date = $date->setTimezone($tz);
 
         return new static($date->format(self::FORMAT), $tz);
     }

--- a/tests/Unit/DDDStarterPack/Type/DateTimeRFCTest.php
+++ b/tests/Unit/DDDStarterPack/Type/DateTimeRFCTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\DDDStarterPack\Type;
+
+use DDDStarterPack\Type\DateTimeRFC;
+use PHPUnit\Framework\TestCase;
+
+class DateTimeRFCTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_should_create_utc_date_time_from_different_timezone_date_time_string(): void
+    {
+        $now = new DateTimeRFC('2024-06-27T21:06:37.879786+02:00');
+        $nowToUTC = DateTimeRFC::UTCfrom($now->value());
+
+        self::assertSame('2024-06-27T21:06:37.879786+02:00', $now->value());
+        self::assertSame('2024-06-27T19:06:37.879786+00:00', $nowToUTC->value());
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_create_utc_date_time(): void
+    {
+        $utc = DateTimeRFC::UTC();
+
+        $timezone = $utc->getTimezone();
+        self::assertInstanceOf(\DateTimeZone::class, $timezone);
+        self::assertSame('UTC', $timezone->getName());
+    }
+}


### PR DESCRIPTION
There was a bug setting the UTC timezone in the DateTimeRFC::UTCfrom() method.
It has been fixed, plus I created a unit test for the use case.